### PR TITLE
Use rest-client instead of rest_client.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,5 +2,6 @@ require "bundler/gem_tasks"
 
 require "rspec/core/rake_task"
 
-desc "Run all specs"
-RSpec::Core::RakeTask.new('spec')
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/promise_pay.gemspec
+++ b/promise_pay.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activesupport", ">= 2.3"
   spec.add_runtime_dependency "json"
-  spec.add_runtime_dependency "rest_client"
+  spec.add_runtime_dependency "rest-client", "~> 1.7"
 end

--- a/promise_pay.gemspec
+++ b/promise_pay.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
 
   spec.add_runtime_dependency "rest_client"
   spec.add_runtime_dependency "json"

--- a/promise_pay.gemspec
+++ b/promise_pay.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 
-  spec.add_runtime_dependency "rest_client"
+  spec.add_runtime_dependency "activesupport", ">= 2.3"
   spec.add_runtime_dependency "json"
+  spec.add_runtime_dependency "rest_client"
 end


### PR DESCRIPTION
rest-client is the official version of the gem, rest_client is a fork that has significantly diverged. The driver for this change is that rest-client honours the default ruby SSL version, while rest_client still overrides it to SSLv3.
