### PR TITLE
Make fee_ids param optional for session request

### DIFF
--- a/lib/promise_pay/session.rb
+++ b/lib/promise_pay/session.rb
@@ -98,7 +98,6 @@ module PromisePay
         :external_item_id,
         :external_seller_id,
         :external_buyer_id,
-        :fee_ids,
         :payment_type_id,
         :seller_country,
         :buyer_country

--- a/lib/promise_pay/version.rb
+++ b/lib/promise_pay/version.rb
@@ -1,3 +1,3 @@
 module PromisePay
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
Some marketplaces don't require a cut, therefore fee_ids become optional.
